### PR TITLE
Added Suspanse boundary to fix the npm run build error

### DIFF
--- a/app/update-prompt/page.jsx
+++ b/app/update-prompt/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import Form from "@components/Form";
@@ -66,4 +66,11 @@ const UpdatePrompt = () => {
   );
 };
 
-export default UpdatePrompt;
+
+const UpdatePromptPage = () => (
+  <Suspense fallback={<div>Loading...</div>}>
+    <UpdatePrompt />
+  </Suspense>
+)
+
+export default UpdatePromptPage;


### PR DESCRIPTION
Since the page `update-prompt` was returning an error indicating it needs to be wrapped in a Suspense component, I did that.

```
<Suspense fallback={<div>Loading...</div>}>
    <UpdatePrompt />
</Suspense>
```

This solves the issue.